### PR TITLE
Generate passwords without dashes, prevent user creation bug.

### DIFF
--- a/scripts/bash/mkuser.bash
+++ b/scripts/bash/mkuser.bash
@@ -20,7 +20,7 @@ make_user() {
   if ! grep -q $new_guy /etc/passwd
   then
     >&2 echo "MESSAGE: Username $new_guy doesn't exists"
-    made_rand=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c7`
+    made_rand=`< /dev/urandom tr -dc '[:alnum:]' | head -c7`
     made_pass=`mkpasswd --method=sha-256 $made_rand`
     #user_group="unknown"
     sudo useradd --password $made_pass \


### PR DESCRIPTION
The original code allowed dashes, which occasionally generated a password beginning with a dash, breaking downstream shell commands. This patch generates passwords without dashes, fixing that.